### PR TITLE
fixed vue router params mapping to fix reset button

### DIFF
--- a/src/components/Game/Game.vue
+++ b/src/components/Game/Game.vue
@@ -2,7 +2,7 @@
 
 <script>
 export default {
-  props: ["code", "player"],
+  props: ["code", "player", "query"],
   name: "game",
   data() {
     return {
@@ -78,8 +78,7 @@ export default {
     }
   },
   mounted() {
-    if (this.$route.query && this.$route.query.is_dealer) {
-      this.code = this.$route.params.code; // vue router issue. when query param was set, props doesn't works well
+    if (this.query && this.query.is_dealer) {
       this.isDealer = true;
     }
     this.getSettings(this.code);

--- a/src/router.js
+++ b/src/router.js
@@ -44,8 +44,9 @@ const routes = [
     path: '/game/:code',
     name: 'dealer',
     component: Game,
-    props: (route) => ({
-      query: route.query.is_dealer
+    props: route => ({
+      code: route.params.code,
+      query: route.query
     }),
     tab: "home",
   },
@@ -68,7 +69,7 @@ const router = new Router({
       // cache home tab
       if (route.tab != "home") {
         store.dispatch('updateHomeTab', from)
-      } 
+      }
       // apply cached home tab then remove it
       if (route.name == "dummy") {
         next(store.state.homeTab.route || routes[0])


### PR DESCRIPTION
### トリガー：
 vuex 実装による揮発領域の圧迫

### 原因：
 `this.code` が揮発したことにより、firebase realtimedatabase のクエリが期待通り実行できなかった。

### 観察と考察：
#### 観察
vue router でのプロパティマッピング機能を間違えて実装したことにより、 this.code は初期状態でundefined になっていた、この値は props::code からコピーされてきた値になる。これを補うため、 mounted 句の中で this.code を $router から読み取った値で上書き使用していた。

#### 考察
this.code の値は本来 props から読み取る、実際 dealer モード以外ではそれで読み取りができていた。今回、vuexを実装したことにより、メモリ使用が肥大化したことで スタックメモリ領域（vue の実装がわからにので論理的な意味、つまり関数実行時使用メモリ）が圧迫され、this.code が揮発してしまった。本来であれば再度参照時に vue が props から値を再充填してくれるはずが、props::code は undefined であったため、 undefined が充填される。以上が原因と考えられる。
何故このタイミング、またresetでのみ起こったのかは不明。