### PR TITLE
FIX kicking user

### DIFF
--- a/src/components/Game/Game.html
+++ b/src/components/Game/Game.html
@@ -89,7 +89,7 @@
                 <div class="md-layout md-alignment-center">
                     <md-button v-bind:class="{'md-primary': !isDecided, 'md-accent' : isDecided}" class="md-raised"
                         :disabled="isFinished || !selectedCard"
-                        @click="isDecided ? cancelOwnScore(playerId, scores) : updateScores(selectedCard, playerId, scores)">
+                        @click="isDecided ? removeScoreById(playerId, scores) : updateScores(selectedCard, playerId, scores)">
                         {{ buttonText }}</md-button>
                 </div>
             </div>

--- a/src/components/Game/Game.vue
+++ b/src/components/Game/Game.vue
@@ -109,6 +109,7 @@ export default {
         if (kickTarget === member) {
           this.members.splice(i, 1)
           this.kickTarget = null
+          this.removeScoreById(i, this.scores)
           break
         }
       }
@@ -127,7 +128,7 @@ export default {
       scores.push([playerId, number])
       this.writeScore(scores)
     },
-    cancelOwnScore: function (playerId, scores) {
+    removeScoreById: function (playerId, scores) {
       if (!this.scores || this.scores === undefined) {
         return
       }


### PR DESCRIPTION
リザルト画面で、user キックする時スコアの修正をしていなかったので、スコアの状態がメンバー状態と不一致になることを修正。詳しくはlinked issue