### PR TITLE
fixed kick action not to break up score list

### DIFF
--- a/src/components/Game/Game.vue
+++ b/src/components/Game/Game.vue
@@ -133,9 +133,9 @@ export default {
       for (const i in this.members) {
         const member = this.members[i]
         if (kickTarget === member) {
+          this.removeScoreById(i, this.scores)
           this.members.splice(i, 1)
           this.kickTarget = null
-          this.removeScoreById(i, this.scores)
           break
         }
       }


### PR DESCRIPTION
member list から人を除外してから、scoreから除外してたので、scoreリストがずれることがあったので、
scoreから除外してから、memberl listを更新するようにした。

## 再現方法

1. planning poker をスタートする
1. playerを三人追加する
1. playerのうち二人が見積を終わらせる（何を入れても良い
1. Dealer は見積を終わらせていない一人をキックする

### 修正前
* 見積を終わらせたうちの一人の見積がwaitingに戻る
* そのまま見積終わらせたら、結果では３人分の結果になる（名前はブランク

### 修正後
* ただちに見積が終了して結果画面に移る。
* スコアは正しくキープされる。